### PR TITLE
Recommended changes from discussion

### DIFF
--- a/Unity/Assets/VectorWar/Runtime/Scripts/VwGame.cs
+++ b/Unity/Assets/VectorWar/Runtime/Scripts/VwGame.cs
@@ -111,7 +111,7 @@ namespace VectorWar {
     }
 
     [Serializable]
-    public struct VwGame : IGame {
+    public class VwGame : IGame {
         public int Framenumber { get; private set; }
 
         public int Checksum => GetHashCode();

--- a/Unity/Packages/SharedGame/Runtime/Scripts/GGPORunner.cs
+++ b/Unity/Packages/SharedGame/Runtime/Scripts/GGPORunner.cs
@@ -26,6 +26,8 @@ namespace SharedGame {
         private Stopwatch frameWatch = new Stopwatch();
         private Stopwatch idleWatch = new Stopwatch();
 
+        private int framesAhead;
+
         /*
          * The begin game callback.  We don't need to do anything special here,
          * so just return true.
@@ -81,7 +83,7 @@ namespace SharedGame {
         }
 
         public bool OnEventEventcodeTimesyncDelegate(int timesync_frames_ahead) {
-            Utils.Sleep(1000 * timesync_frames_ahead / 60);
+            framesAhead = timesync_frames_ahead;
             return true;
         }
 
@@ -366,6 +368,12 @@ namespace SharedGame {
         */
 
         public void RunFrame() {
+            if (framesAhead > 0) {
+                // Need to capture inputs we don't use on this frame and make them available for the next frame we don't skip
+                framesAhead--;
+                return;
+            }
+            
             var result = GGPO.OK;
 
             for (int i = 0; i < GameInfo.players.Length; ++i) {

--- a/Unity/Packages/SharedGame/Runtime/Scripts/LocalRunner.cs
+++ b/Unity/Packages/SharedGame/Runtime/Scripts/LocalRunner.cs
@@ -21,7 +21,7 @@ namespace SharedGame {
 
         public void Idle(int ms) {
             idleWatch.Start();
-            Utils.Sleep(ms);
+            // We don't need to sleep here anymore as we are running idle before RunFrame every fixed update
             idleWatch.Stop();
         }
 


### PR DESCRIPTION
Changed GameManager to use FixedUpdate rather than Update (RunFrame must be separated from render frame rate)
Change VwGame struct to a class so the Framenumber property persists Removed thread.sleep in LocalRunner
Removed thread.sleep in TimesyncDelegate and replaced with member framesAhead, which is used to skip RunFrames when above 0

I wouldn't necessarily merge this is in as I haven't thoroughly tested this code for Vector War, I just wanted to give you an idea of what the changes look like!